### PR TITLE
See #127.  Fixed residual issues because of the renaming of the PTF d…

### DIFF
--- a/examples/ptf_udf_row_driven/java/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/ptf_udf_row_driven/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/ptf_udf_row_driven/java/gradlew
+++ b/examples/ptf_udf_row_driven/java/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/2d6327017519d23b96af35865dc997fcb544fb40/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/examples/ptf_udf_timer_driven/java/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/ptf_udf_timer_driven/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/ptf_udf_timer_driven/java/gradlew
+++ b/examples/ptf_udf_timer_driven/java/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/2d6327017519d23b96af35865dc997fcb544fb40/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/k8s/base/flink-basic-deployment.yaml
+++ b/k8s/base/flink-basic-deployment.yaml
@@ -15,9 +15,9 @@ spec:
   flinkVersion: ${FLINK_VERSION}
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-    # Dev-friendly: low memory footprint for Minikube
-    jobmanager.memory.process.size: "1024m"
-    taskmanager.memory.process.size: "1024m"
+    # Dev-friendly: sized for Minikube
+    jobmanager.memory.process.size: "2048m"
+    taskmanager.memory.process.size: "2048m"
     # Remote debugging: JDWP agent on TaskManager (suspend=n so processing starts immediately)
     env.java.opts.taskmanager: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     # Increase heartbeat timeout to avoid TaskManager death while paused at breakpoints
@@ -62,12 +62,12 @@ spec:
           emptyDir: {}
   jobManager:
     resource:
-      memory: "1024m"
+      memory: "2048m"
       cpu: 0.5
     replicas: 1
   taskManager:
     resource:
-      memory: "1024m"
+      memory: "2048m"
       cpu: 0.5
     replicas: 1
   # No `job:` section = session cluster mode.


### PR DESCRIPTION
## Summary
- Regenerated Gradle wrappers for both `ptf_udf_row_driven` and `ptf_udf_timer_driven` examples (the `gradle-wrapper.jar` is `.gitignore`d and was not carried over by the directory rename in PR #128)
- Bumped Gradle wrapper version from 9.3.1 to 9.4.1 (result of running `gradle wrapper` with the locally installed Gradle)
- Increased Flink JobManager and TaskManager memory from 1024m to 2048m to fix OOM-kill (exit code 137) when running `sql-client.sh` on the JobManager pod

## What changed
| File | Change |
|---|---|
| `examples/ptf_udf_row_driven/java/gradle/wrapper/gradle-wrapper.properties` | Gradle 9.3.1 → 9.4.1 |
| `examples/ptf_udf_row_driven/java/gradlew` | Updated by `gradle wrapper` |
| `examples/ptf_udf_timer_driven/java/gradle/wrapper/gradle-wrapper.properties` | Gradle 9.3.1 → 9.4.1 |
| `examples/ptf_udf_timer_driven/java/gradlew` | Updated by `gradle wrapper` |
| `k8s/base/flink-basic-deployment.yaml` | JM & TM memory: 1024m → 2048m |

## Test plan
- [ ] Verify `make build-ptf-udf-row-driven` succeeds
- [ ] Verify `make build-ptf-udf-timer-driven` succeeds
- [ ] Verify `make deploy-cp-ptf-udf-row-driven` completes without OOM
- [ ] Verify `make deploy-cp-ptf-udf-timer-driven` completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)